### PR TITLE
Fixed Command Injection

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ function buildRpm(buildRoot, specFile, rpmDest, execOpts, cb) {
 
   execOpts = execOpts || {};
 
-  execFile(cmdFile, [cmd], execOpts, function rpmbuild(err, stdout) {
+  execFile(cmdFile, cmd, execOpts, function rpmbuild(err, stdout) {
 
     if (err) {
       return cb(err);

--- a/index.js
+++ b/index.js
@@ -123,10 +123,12 @@ function buildRpm(buildRoot, specFile, rpmDest, execOpts, cb) {
     buildRoot,
     specFile
   ];
+  
   var cmdFile = cmd[0];
-  cmd.shift();
-
+  
   logger(chalk.cyan('Executing:'), cmd);
+  
+  cmd.shift();
 
   execOpts = execOpts || {};
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var chalk = require('chalk');
-var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 var fsx = require('fs-extra');
 var globby = require('globby');
 var path = require('path');
@@ -122,13 +122,15 @@ function buildRpm(buildRoot, specFile, rpmDest, execOpts, cb) {
     '--buildroot',
     buildRoot,
     specFile
-  ].join(' ');
+  ];
+  var cmdFile = cmd[0];
+  cmd.shift();
 
   logger(chalk.cyan('Executing:'), cmd);
 
   execOpts = execOpts || {};
 
-  exec(cmd, execOpts, function rpmbuild(err, stdout) {
+  execFile(cmdFile, [cmd], execOpts, function rpmbuild(err, stdout) {
 
     if (err) {
       return cb(err);


### PR DESCRIPTION
### ⚙️ Description *

The vulnerability is caused due to the usage of `child_process`'s `exec()` function which is vulnerable to Command Injection. Replacing the `exec()` function with `execFile()` function will mitigate this vulnerability.

### 💻 Technical Description *

The occurrence of this vulnerability is caused due to the usage of the `exec()` function. So replacing the `exec()` function with `execFile()` is enough to fix the issue.

Here is how it works:

```javascript
var cmd = [
  'rpmbuild',
  '-bb',
  '--buildroot',
  buildRoot,
  specFile
];
var cmdFile = cmd[0];
cmd.shift();
```

The `cmd` array which includes user inputs is being mutated here. The first element is obviously the binary/shell execution file. Here it is `rpmbuild`. Then the first element is deleted from the array with the `shift()` function, this is to give it as arguments array to the `execFile()` function. So all together it becomes:

```javascript
var cmd = [
  'rpmbuild',
  '-bb',
  '--buildroot',
  buildRoot,
  specFile
];
var cmdFile = cmd[0];
cmd.shift();

logger(chalk.cyan('Executing:'), cmd);

execOpts = execOpts || {};

execFile(cmdFile, [cmd], execOpts, function rpmbuild(err, stdout) {

  if (err) {
    return cb(err);
  }

  if (stdout) {
    var rpm = stdout.match(/(\/.+\..+\.rpm)/);

    if (rpm && rpm.length > 0) {
      var rpmDestination = rpm[0];

      if (rpmDest) {
        rpmDestination = path.join(rpmDest, path.basename(rpmDestination));
        logger(chalk.cyan('Copying RPM package to:'), rpmDestination);
        fsx.copySync(rpm[0], rpmDestination);
      }

      return cb(null, rpmDestination);
    }
  }
});
```

### 🐛 Proof of Concept (PoC) *

_**Place this file under the root directory of the project (`poc.js`)**_

```javascript
// poc.js
var buildRpm = require('./index.js');
buildRpm({'tempDir':'test; touch HACKED; #'}, function(e){console.log(e)});
```

### 🔥 Proof of Fix (PoF) *

    $ cd node-rpm-builder/
    $ npm install
    $ node poc.js

![node-rpm-builder-fix](https://user-images.githubusercontent.com/26198477/81429616-ab599080-917b-11ea-801b-e28ddc7856e9.png)

As you can see in the above screenshot, there is no file named `HACKED` thus fixing the issue.

**NOTE:**

_The folder `'test; touch HACKED; #'` is not part of the issue, that folder is created by the following code:_

```javascript
fsx.mkdirpSync(path.join(tmpDir, dirName));
```

### 👍 User Acceptance Testing (UAT)

The replacement of the `exec()` function with `execFile()` is the only change implemented.
